### PR TITLE
Upgraded hyper to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ keywords = ["hipchat"]
 
 [dependencies]
 rustc-serialize = "0.3"
-hyper = "0.7"
-url = "0.5"
+hyper = "0.10"
+hyper-native-tls = "0.2"
+url = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate hyper;
+extern crate hyper_native_tls;
 extern crate rustc_serialize;
 extern crate url;
 

--- a/src/room.rs
+++ b/src/room.rs
@@ -1,7 +1,11 @@
 use rustc_serialize::{Decodable, Decoder};
 
-use util::{Privacy};
+use util::{Privacy, AppendToQueryParams};
 use message::{Color, MessageFormat};
+
+use url::UrlQuery;
+use url::form_urlencoded::Serializer;
+
 
 #[derive(Debug, Hash, Eq, PartialEq)]
 pub struct RoomsRequest {
@@ -9,6 +13,15 @@ pub struct RoomsRequest {
     pub max_results: Option<u64>,
     pub include_private: Option<bool>,
     pub include_archived: Option<bool>
+}
+
+impl AppendToQueryParams for RoomsRequest {
+    fn append_to(&self, query: &mut Serializer<UrlQuery>){
+        self.start_index.map(|start_index| query.append_pair("start-index", &start_index.to_string()));
+        self.max_results.map(|max_results| query.append_pair("max-results", &max_results.to_string()));
+        self.include_private.map(|include_private| query.append_pair("include-private", &include_private.to_string()));
+        self.include_archived.map(|include_archived| query.append_pair("include-archived", &include_archived.to_string()));
+    }
 }
 
 #[derive(Debug, Hash, Eq, PartialEq)]
@@ -176,6 +189,7 @@ impl Default for Notification {
 mod test {
     use super::*;
     use rustc_serialize::json;
+    use url::Url;
 
     #[test]
     fn unit_rooms_links() {
@@ -190,5 +204,33 @@ mod test {
             "next":"https://www.example.com"
         }"#).unwrap();
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn unit_default_rooms_request_should_create_empty_params(){
+        let rooms_request = RoomsRequest{ start_index: None,
+                                          max_results: None,
+                                          include_private: None,
+                                          include_archived: None };
+
+        let mut url = Url::parse("https://rsolomo.github.io/hipchat-client/hipchat_client/index.html").unwrap();
+
+        rooms_request.append_to(&mut url.query_pairs_mut());
+
+        assert_eq!(Some(""), url.query());
+    }
+
+    #[test]
+    fn unit_populated_rooms_request_should_create_encoded_params(){
+        let rooms_request = RoomsRequest{ start_index: Some(1),
+                                          max_results: Some(10),
+                                          include_private: Some(true),
+                                          include_archived: Some(true) };
+
+        let mut url = Url::parse("https://rsolomo.github.io/hipchat-client/hipchat_client/index.html").unwrap();
+
+        rooms_request.append_to(&mut url.query_pairs_mut());
+
+        assert_eq!(Some("start-index=1&max-results=10&include-private=true&include-archived=true"), url.query());
     }
 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,5 +1,9 @@
 use rustc_serialize::{Decodable, Decoder};
 
+use util::AppendToQueryParams;
+use url::UrlQuery;
+use url::form_urlencoded::Serializer;
+
 #[derive(Debug, Hash, Eq, PartialEq)]
 pub struct UsersRequest {
     pub start_index: Option<u64>,
@@ -16,6 +20,15 @@ impl Default for UsersRequest {
             include_guests: Some(false),
             include_deleted: Some(false),
         }
+    }
+}
+
+impl AppendToQueryParams for UsersRequest {
+    fn append_to(&self, query: &mut Serializer<UrlQuery>){
+        self.start_index.map(|start_index| query.append_pair("start-index", &start_index.to_string()));
+        self.max_results.map(|max_results| query.append_pair("max-results", &max_results.to_string()));
+        self.include_guests.map(|include_guests| query.append_pair("include-guests", &include_guests.to_string()));
+        self.include_deleted.map(|include_deleted| query.append_pair("include-deleted", &include_deleted.to_string()));
     }
 }
 
@@ -140,6 +153,7 @@ pub struct UserMessage {
 mod test {
     use super::*;
     use rustc_serialize::json;
+    use url::Url;
 
     #[test]
     fn unit_users_links() {
@@ -154,5 +168,33 @@ mod test {
             "next":"https://www.example.com"
         }"#).unwrap();
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn unit_default_users_request_should_create_empty_params(){
+        let users_request = UsersRequest{ start_index: None,
+                                          max_results: None,
+                                          include_guests: None,
+                                          include_deleted: None };
+
+        let mut url = Url::parse("https://rsolomo.github.io/hipchat-client/hipchat_client/index.html").unwrap();
+
+        users_request.append_to(&mut url.query_pairs_mut());
+
+        assert_eq!(Some(""), url.query());
+    }
+
+    #[test]
+    fn unit_populated_users_request_should_create_encoded_params(){
+        let users_request = UsersRequest{ start_index: Some(1),
+                                          max_results: Some(10),
+                                          include_guests: Some(true),
+                                          include_deleted: Some(true) };
+
+        let mut url = Url::parse("https://rsolomo.github.io/hipchat-client/hipchat_client/index.html").unwrap();
+
+        users_request.append_to(&mut url.query_pairs_mut());
+
+        assert_eq!(Some("start-index=1&max-results=10&include-guests=true&include-deleted=true"), url.query());
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,6 +2,9 @@ use std::str::FromStr;
 
 use rustc_serialize::{Encodable, Decodable, Decoder, Encoder};
 
+use url::UrlQuery;
+use url::form_urlencoded::Serializer;
+
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub enum Privacy {
     Public,
@@ -47,6 +50,10 @@ impl Encodable for Privacy {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         s.emit_str(self.as_ref())
     }
+}
+
+pub trait AppendToQueryParams {
+    fn append_to(&self, query: &mut Serializer<UrlQuery>);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Upgrade involved a new tls crate, new ways to add/encode query parameters, and test coverage.

I wanted to use this library with the [git2](https://crates.io/crates/git2) crate, but they were linking incompatible openssl-sys crates. Upgrading hyper to the latest crate fixed the issue. I figured that it would make sense to see if you wanted to include this change rather than maintain a fork for my use case.

I tried to follow your project's style conventions, but I would be happy to make any further changes that you would want with this PR.