### PR TITLE
replace rustc_serialize with serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ description = "An API client library for HipChat"
 keywords = ["hipchat"]
 
 [dependencies]
-rustc-serialize = "0.3"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
 hyper = "0.10"
 hyper-native-tls = "0.2"
 url = "1.0"

--- a/src/emoticon.rs
+++ b/src/emoticon.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Hash, Eq, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Emoticon {
     pub width: u64,
     pub audio_path: Option<String>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use std::fmt::{Display, Formatter};
 use std::io::Error as IoError;
 use hyper::error::Error as HyperError;
 use hyper::status::StatusCode;
-use rustc_serialize::json::DecoderError as JsonError;
+use serde_json::error::Error as JsonError;
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 extern crate hyper;
 extern crate hyper_native_tls;
-extern crate rustc_serialize;
+#[macro_use]
+extern crate serde_derive;
+
+extern crate serde;
+extern crate serde_json;
 extern crate url;
 
 pub mod client;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,12 +1,11 @@
-use std::str::FromStr;
-use rustc_serialize::{Decodable, Encodable, Decoder, Encoder};
 use user::{UserDetail};
 
 use util::AppendToQueryParams;
 use url::UrlQuery;
 use url::form_urlencoded::Serializer;
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Color {
     Yellow,
     Green,
@@ -22,103 +21,18 @@ impl Default for Color {
     }
 }
 
-impl FromStr for Color {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "yellow" => Ok(Color::Yellow),
-            "green" => Ok(Color::Green),
-            "red" => Ok(Color::Red),
-            "purple" => Ok(Color::Purple),
-            "gray" => Ok(Color::Gray),
-            "random" => Ok(Color::Random),
-            _ => Err(())
-        }
-    }
-}
-
-impl AsRef<str> for Color {
-    fn as_ref(&self) -> &str {
-        match *self {
-            Color::Yellow => "yellow",
-            Color::Green => "green",
-            Color::Red => "red",
-            Color::Purple => "purple",
-            Color::Gray => "gray",
-            Color::Random => "random"
-        }
-    }
-}
-
-impl Decodable for Color {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
-        d.read_str().and_then(|s| {
-            s.parse().map_err(|_| d.error("invalid value for color"))
-        })
-    }
-}
-
-impl Encodable for Color {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_str(self.as_ref())
-    }
-}
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum MessageType {
     Message,
+    #[serde(rename = "guest_access")]
     GuestAccess,
     Topic,
     Notification
 }
 
-impl Default for MessageType {
-    fn default() -> Self {
-        MessageType::Message
-    }
-}
-
-impl FromStr for MessageType {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "message" => Ok(MessageType::Message),
-            "guest_access" => Ok(MessageType::GuestAccess),
-            "topic" => Ok(MessageType::Topic),
-            "notification" => Ok(MessageType::Notification),
-            _ => Err(())
-        }
-    }
-}
-
-impl AsRef<str> for MessageType {
-    fn as_ref(&self) -> &str {
-        match *self {
-            MessageType::Message => "message",
-            MessageType::GuestAccess => "guest_access",
-            MessageType::Topic => "topic",
-            MessageType::Notification => "notification"
-        }
-    }
-}
-
-impl Decodable for MessageType {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
-        d.read_str().and_then(|s| {
-            s.parse().map_err(|_| d.error("invalid value for message type"))
-        })
-    }
-}
-
-impl Encodable for MessageType {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_str(self.as_ref())
-    }
-}
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum MessageFormat {
     Html,
     Text
@@ -130,42 +44,7 @@ impl Default for MessageFormat {
     }
 }
 
-impl FromStr for MessageFormat {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "html" => Ok(MessageFormat::Html),
-            "text" => Ok(MessageFormat::Text),
-            _ => Err(())
-        }
-    }
-}
-
-impl AsRef<str> for MessageFormat {
-    fn as_ref(&self) -> &str {
-        match *self {
-            MessageFormat::Html => "html",
-            MessageFormat::Text => "text"
-        }
-    }
-}
-
-impl Decodable for MessageFormat {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
-        d.read_str().and_then(|s| {
-            s.parse().map_err(|_| d.error("invalid value for message_format"))
-        })
-    }
-}
-
-impl Encodable for MessageFormat {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_str(self.as_ref())
-    }
-}
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MessagesRequest {
     pub start_index: Option<u64>,
     pub max_results: Option<u64>,
@@ -188,43 +67,23 @@ impl AppendToQueryParams for MessagesRequest {
     }
 }
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize)]
 pub struct MessageDetailLinks {
+    #[serde(rename = "self")]
     pub self_: String,
 }
 
-impl Decodable for MessageDetailLinks {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
-        d.read_struct("root", 4, |d| {
-            Ok(MessageDetailLinks {
-                self_: try!(d.read_struct_field("self", 0, Decodable::decode)),
-            })
-        })
-    }
-}
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize)]
 pub struct Messages {
+    #[serde(skip_deserializing)]
     pub start_index: u64,
+    #[serde(skip_deserializing)]
     pub max_results: u64,
     pub items: Vec<Message>,
     pub links: MessageDetailLinks
 }
 
-impl Decodable for Messages {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
-        d.read_struct("root", 4, |d| {
-            Ok(Messages {
-                start_index: try!(d.read_struct_field("startIndex", 0, Decodable::decode)),
-                max_results: try!(d.read_struct_field("maxResults", 0, Decodable::decode)),
-                items: try!(d.read_struct_field("items", 0, Decodable::decode)),
-                links: try!(d.read_struct_field("links", 0, Decodable::decode)),
-            })
-        })
-    }
-}
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq, RustcDecodable)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize)]
 pub struct MessageFile {
     pub url: String,
     pub thumb_url: Option<String>,
@@ -232,7 +91,13 @@ pub struct MessageFile {
     pub size: u64
 }
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct SendMessageResponse {
+    pub id: String,
+    pub timestamp: String
+}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize)]
 pub struct Message {
     pub id: String,
     pub date: String,
@@ -245,50 +110,32 @@ pub struct Message {
     pub file: Option<MessageFile>,
 }
 
-impl Decodable for Message {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
-        d.read_struct("root", 4, |d| {
-            Ok(Message {
-                id: try!(d.read_struct_field("id", 0, Decodable::decode)),
-                date: try!(d.read_struct_field("date", 0, Decodable::decode)),
-                from: try!(d.read_struct_field("from", 0, Decodable::decode)),
-                message: try!(d.read_struct_field("message", 0, Decodable::decode)),
-                message_format: try!(d.read_struct_field("message_format", 0, Decodable::decode)),
-                message_type: try!(d.read_struct_field("type", 0, Decodable::decode)),
-                color: try!(d.read_struct_field("color", 0, Decodable::decode)),
-                mentions: try!(d.read_struct_field("mentions", 0, Decodable::decode)),
-                file: try!(d.read_struct_field("file", 0, Decodable::decode)),
-            })
-        })
-    }
-}
-
-
 #[cfg(test)]
 mod test {
     use super::*;
-    use rustc_serialize::json;
+    use serde_json::{self};
     use url::Url;
 
     #[test]
     fn unit_deserialize_message_format_html() {
         let expected = MessageFormat::Html;
-        let actual = json::decode::<MessageFormat>("\"html\"")
-            .unwrap_or_else(|e| panic!("{}", e));
+        let actual: MessageFormat = serde_json::from_str("\"html\"")
+            .unwrap_or_else(|e| panic!("{:?}", e));
         assert_eq!(actual, expected);
     }
 
     #[test]
     fn unit_deserialize_message_format_text() {
         let expected = MessageFormat::Text;
-        let actual = json::decode::<MessageFormat>("\"text\"")
-            .unwrap_or_else(|e| panic!("{}", e));
+        let actual: MessageFormat = serde_json::from_str("\"text\"")
+            .unwrap_or_else(|e| panic!("{:?}", e));
         assert_eq!(actual, expected);
     }
 
     #[test]
     fn unit_serialize_message_format_text() {
-        let actual = json::encode(&MessageFormat::Text).unwrap();
+        let text = MessageFormat::Text;
+        let actual = serde_json::to_string(&text).unwrap();
         let expected = "\"text\"";
         assert_eq!(actual, expected);
     }

--- a/src/room.rs
+++ b/src/room.rs
@@ -1,5 +1,3 @@
-use rustc_serialize::{Decodable, Decoder};
-
 use util::{Privacy, AppendToQueryParams};
 use message::{Color, MessageFormat};
 
@@ -24,54 +22,32 @@ impl AppendToQueryParams for RoomsRequest {
     }
 }
 
-#[derive(Debug, Hash, Eq, PartialEq)]
+#[derive(Debug, Hash, Eq, PartialEq, Deserialize)]
 pub struct Rooms {
+    #[serde(rename = "startIndex")]
     pub start_index: u64,
+    #[serde(rename = "maxResults")]
     pub max_results: u64,
     pub items: Vec<Room>,
     pub links: RoomsLinks
 }
 
-impl Decodable for Rooms {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
-        d.read_struct("root", 4, |d| {
-            Ok(Rooms {
-                start_index: try!(d.read_struct_field("startIndex", 0, Decodable::decode)),
-                max_results: try!(d.read_struct_field("maxResults", 0, Decodable::decode)),
-                items: try!(d.read_struct_field("items", 0, Decodable::decode)),
-                links: try!(d.read_struct_field("links", 0, Decodable::decode)),
-            })
-        })
-    }
-}
-
-#[derive(Debug, Hash, Eq, PartialEq)]
+#[derive(Debug, Hash, Eq, PartialEq, Deserialize)]
 pub struct RoomsLinks {
+    #[serde(rename = "self")]
     pub self_: String,
     pub prev: Option<String>,
     pub next: Option<String>
 }
 
-impl Decodable for RoomsLinks {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
-        d.read_struct("root", 3, |d| {
-            Ok(RoomsLinks {
-                self_: try!(d.read_struct_field("self", 0, Decodable::decode)),
-                prev: try!(d.read_struct_field("prev", 1, Decodable::decode)),
-                next: try!(d.read_struct_field("next", 2, Decodable::decode))
-            })
-        })
-    }
-}
-
-#[derive(Debug, Hash, Eq, PartialEq, RustcDecodable)]
+#[derive(Debug, Hash, Eq, PartialEq, Deserialize)]
 pub struct Room {
     pub name: String,
     pub id: u64,
     pub links: RoomDetailLinks
 }
 
-#[derive(Debug, Hash, Eq, PartialEq, RustcDecodable)]
+#[derive(Debug, Hash, Eq, PartialEq, Deserialize)]
 pub struct RoomDetail {
     pub xmpp_jid: String,
     pub statistics: RoomDetailStatistics,
@@ -87,48 +63,27 @@ pub struct RoomDetail {
     pub guest_access_url: Option<String>
 }
 
-#[derive(Debug, Hash, Eq, PartialEq, RustcDecodable)]
+#[derive(Debug, Hash, Eq, PartialEq, Deserialize)]
 pub struct RoomDetailStatistics {
     pub links: RoomDetailStatisticsLinks
 }
 
-#[derive(Debug, Hash, Eq, PartialEq)]
+#[derive(Debug, Hash, Eq, PartialEq, Deserialize)]
 pub struct RoomDetailStatisticsLinks {
+    #[serde(rename = "self")]
     pub self_: String
 }
 
-impl Decodable for RoomDetailStatisticsLinks {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
-        d.read_struct("root", 1, |d| {
-            Ok(RoomDetailStatisticsLinks {
-                self_: try!(d.read_struct_field("self", 0, Decodable::decode))
-            })
-        })
-    }
-}
-
-#[derive(Debug, Hash, Eq, PartialEq)]
+#[derive(Debug, Hash, Eq, PartialEq, Deserialize)]
 pub struct RoomDetailLinks {
+    #[serde(rename = "self")]
     pub self_: String,
     pub webhooks: String,
     pub members: Option<String>,
     pub participants: String
 }
 
-impl Decodable for RoomDetailLinks {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
-        d.read_struct("root", 4, |d| {
-            Ok(RoomDetailLinks {
-                self_: try!(d.read_struct_field("self", 0, Decodable::decode)),
-                webhooks: try!(d.read_struct_field("webhooks", 1, Decodable::decode)),
-                members: try!(d.read_struct_field("members", 2, Decodable::decode)),
-                participants: try!(d.read_struct_field("participants", 3, Decodable::decode))
-            })
-        })
-    }
-}
-
-#[derive(Debug, Hash, Eq, PartialEq, RustcDecodable)]
+#[derive(Debug, Hash, Eq, PartialEq, Deserialize)]
 pub struct RoomDetailOwner {
     pub mention_name: String,
     pub id: u64,
@@ -136,22 +91,13 @@ pub struct RoomDetailOwner {
     pub name: String
 }
 
-#[derive(Debug, Hash, Eq, PartialEq)]
+#[derive(Debug, Hash, Eq, PartialEq, Deserialize)]
 pub struct RoomDetailOwnerLinks {
+    #[serde(rename = "self")]
     pub self_: String
 }
 
-impl Decodable for RoomDetailOwnerLinks {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
-        d.read_struct("root", 1, |d| {
-            Ok(RoomDetailOwnerLinks {
-                self_: try!(d.read_struct_field("self", 0, Decodable::decode))
-            })
-        })
-    }
-}
-
-#[derive(Debug, Hash, Eq, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct RoomUpdate {
     pub name: Option<String>,
     pub privacy: Option<Privacy>,
@@ -161,12 +107,12 @@ pub struct RoomUpdate {
     pub owner: Option<RoomUpdateOwner>
 }
 
-#[derive(Debug, Hash, Eq, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct RoomUpdateOwner {
     pub id: Option<String>
 }
 
-#[derive(Debug, Hash, Eq, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Notification {
     pub color: Color,
     pub message: String,
@@ -188,8 +134,8 @@ impl Default for Notification {
 #[cfg(test)]
 mod test {
     use super::*;
-    use rustc_serialize::json;
     use url::Url;
+    use serde_json::{self};
 
     #[test]
     fn unit_rooms_links() {
@@ -198,7 +144,7 @@ mod test {
             prev: Some("https://www.example.com".to_owned()),
             next: Some("https://www.example.com".to_owned())
         };
-        let actual = json::decode::<RoomsLinks>(r#"{
+        let actual: RoomsLinks = serde_json::from_str(r#"{
             "self":"https://www.example.com",
             "prev":"https://www.example.com",
             "next":"https://www.example.com"

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,5 +1,3 @@
-use rustc_serialize::{Decodable, Decoder};
-
 use util::AppendToQueryParams;
 use url::UrlQuery;
 use url::form_urlencoded::Serializer;
@@ -32,47 +30,25 @@ impl AppendToQueryParams for UsersRequest {
     }
 }
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize)]
 pub struct UsersLinks {
+    #[serde(rename = "self")]
     pub self_: String,
     pub prev: Option<String>,
     pub next: Option<String>
 }
 
-impl Decodable for UsersLinks {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
-        d.read_struct("root", 3, |d| {
-            Ok(UsersLinks {
-                self_: try!(d.read_struct_field("self", 0, Decodable::decode)),
-                prev: try!(d.read_struct_field("prev", 1, Decodable::decode)),
-                next: try!(d.read_struct_field("next", 2, Decodable::decode))
-            })
-        })
-    }
-}
-
-#[derive(Debug, Hash, Eq, PartialEq)]
+#[derive(Debug, Hash, Eq, PartialEq, Deserialize)]
 pub struct Users {
+    #[serde(rename = "startIndex")]
     pub start_index: u64,
+    #[serde(rename = "maxResults")]
     pub max_results: u64,
     pub items: Vec<User>,
     pub links: UsersLinks
 }
 
-impl Decodable for Users {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
-        d.read_struct("root", 4, |d| {
-            Ok(Users {
-                start_index: try!(d.read_struct_field("startIndex", 0, Decodable::decode)),
-                max_results: try!(d.read_struct_field("maxResults", 0, Decodable::decode)),
-                items: try!(d.read_struct_field("items", 0, Decodable::decode)),
-                links: try!(d.read_struct_field("links", 0, Decodable::decode)),
-            })
-        })
-    }
-}
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq, RustcDecodable)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize)]
 pub struct User {
     pub name: String,
     pub mention_name: String,
@@ -80,24 +56,13 @@ pub struct User {
     pub links: UserDetailLinks
 }
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize)]
 pub struct UserClient {
     pub version: Option<String>,
     pub client_type: Option<String>,
 }
 
-impl Decodable for UserClient {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
-        d.read_struct("root", 4, |d| {
-            Ok(UserClient {
-                version: try!(d.read_struct_field("version", 0, Decodable::decode)),
-                client_type: try!(d.read_struct_field("type", 0, Decodable::decode)),
-            })
-        })
-    }
-}
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq, RustcDecodable)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize)]
 pub struct UserPresence {
     pub status: Option<String>,
     pub idle: Option<u64>,
@@ -106,7 +71,7 @@ pub struct UserPresence {
     pub is_online: bool,
 }
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq, RustcDecodable)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize)]
 pub struct UserDetail {
     pub id: u64,
     pub xmpp_jid: Option<String>,
@@ -127,22 +92,13 @@ pub struct UserDetail {
     pub links: UserDetailLinks,
 }
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize)]
 pub struct UserDetailLinks {
+    #[serde(rename = "self")]
     pub self_: String,
 }
 
-impl Decodable for UserDetailLinks {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
-        d.read_struct("root", 4, |d| {
-            Ok(UserDetailLinks {
-                self_: try!(d.read_struct_field("self", 0, Decodable::decode)),
-            })
-        })
-    }
-}
-
-#[derive(Debug, Hash, Eq, PartialEq, RustcDecodable)]
+#[derive(Debug, Hash, Eq, PartialEq, Deserialize)]
 pub struct UserMessage {
     pub id: String,
     pub timestamp: String
@@ -152,7 +108,7 @@ pub struct UserMessage {
 #[cfg(test)]
 mod test {
     use super::*;
-    use rustc_serialize::json;
+    use serde_json::{self};
     use url::Url;
 
     #[test]
@@ -162,7 +118,7 @@ mod test {
             prev: Some("https://www.example.com".to_owned()),
             next: Some("https://www.example.com".to_owned())
         };
-        let actual = json::decode::<UsersLinks>(r#"{
+        let actual: UsersLinks = serde_json::from_str(r#"{
             "self":"https://www.example.com",
             "prev":"https://www.example.com",
             "next":"https://www.example.com"

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,11 +1,8 @@
-use std::str::FromStr;
-
-use rustc_serialize::{Encodable, Decodable, Decoder, Encoder};
-
 use url::UrlQuery;
 use url::form_urlencoded::Serializer;
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Privacy {
     Public,
     Private
@@ -17,41 +14,6 @@ impl Default for Privacy {
     }
 }
 
-impl FromStr for Privacy {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "public" => Ok(Privacy::Public),
-            "private" => Ok(Privacy::Private),
-            _ => Err(())
-        }
-    }
-}
-
-impl AsRef<str> for Privacy {
-    fn as_ref(&self) -> &str {
-        match *self {
-            Privacy::Public => "public",
-            Privacy::Private => "private"
-        }
-    }
-}
-
-impl Decodable for Privacy {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
-        d.read_str().and_then(|s| {
-            s.parse().map_err(|_| d.error("invalid value for privacy"))
-        })
-    }
-}
-
-impl Encodable for Privacy {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_str(self.as_ref())
-    }
-}
-
 pub trait AppendToQueryParams {
     fn append_to(&self, query: &mut Serializer<UrlQuery>);
 }
@@ -59,11 +21,11 @@ pub trait AppendToQueryParams {
 #[cfg(test)]
 mod test {
     use super::*;
-    use rustc_serialize::json;
+    use serde_json::{self};
 
     #[test]
     fn unit_serialize_privacy_private() {
-        let actual = json::encode(&Privacy::Private).unwrap();
+        let actual = serde_json::to_string(&Privacy::Private).unwrap();
         let expected = "\"private\"";
         assert_eq!(actual, expected);
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,13 +1,15 @@
 extern crate hipchat_client;
 extern crate hyper;
-extern crate rustc_serialize;
+#[macro_use]
+extern crate serde_derive;
 
+extern crate serde;
+extern crate serde_json;
 use std::io::prelude::*;
 use std::fs::File;
-use rustc_serialize::json;
 use hipchat_client::Client as HipchatClient;
 
-#[derive(RustcDecodable)]
+#[derive(Deserialize)]
 struct Config {
     token: String,
     origin: String,
@@ -21,7 +23,7 @@ fn setup() -> (HipchatClient, Config) {
         .unwrap_or_else(|e| panic!("{}", e))
         .read_to_string(contents)
         .unwrap_or_else(|e| panic!("{}", e));
-    let config = json::decode::<Config>(contents)
+    let config: Config = serde_json::from_str(contents)
         .unwrap_or_else(|e| panic!("{}", e));
     (HipchatClient::new(config.origin.clone(), config.token.clone()), config)
 }


### PR DESCRIPTION
Per issue https://github.com/rsolomo/hipchat-client/issues/6, proposing the following changes:

* Drop rustc_serialize dependency, use serde
* update_room contains no response per the API docs: https://www.hipchat.com/docs/apiv2/method/update_room
* Add `SendMessageResponse` struct for said API call

Assuming a `settings.json` file is properly created, additional integration tests for the aforementioned changes can be added to `test/lib.rs` as follows:

```
use hipchat_client::room::{RoomUpdate, RoomUpdateOwner};
use hipchat_client::util::Privacy;

#[test]
fn integration_send_message() {
    let (client, config) = setup();
    let foo = r#"some message, cool. ! \/ #####/"#;
    let messages = client.send_message(&config.room, foo.to_string()).unwrap();
    println!("messages: {:#?}", messages);
}

#[test]
fn integration_update_room() {
    let (client, config) = setup();
    let update: RoomUpdate = RoomUpdate {
        name: Some("Ninja".to_owned()),
        privacy: Some(Privacy::Private),
        is_archived: Some(false),
        is_guest_accessible: Some(false),
        owner: Some(RoomUpdateOwner {
            id: Some("someuser@covfefe.com".to_owned())
        }),
        topic: Some("When I rest, I rust.".to_owned())
    };
    println!("{:#?}", update);
    let room_update = client.update_room(&config.room, &update).unwrap();
    println!("update: {:#?}", room_update);
}
```